### PR TITLE
Introduce ClubData context hooks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,13 +15,13 @@ import FindPartnerView from './components/FindPartnerView';
 import AnnouncementsView from './components/AnnouncementsView';
 import MyAccountView from './components/WalletView';
 import LearningCenterView from './components/LearningCenterView';
-import { useClubData } from './hooks/useClubData';
+import { useClubDataContext, useMembers, useBookings, useGroups } from './hooks/ClubDataContext';
 import { View } from './types';
 import SettingsView from './components/SettingsView';
 import PrivacyPolicyView from './components/PrivacyPolicyView';
 
-const DashboardView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { events, members, currentUser, updateAvailability } = clubData;
+const DashboardView: React.FC = () => {
+    const { events, members, currentUser, updateAvailability } = useClubDataContext();
     const sortedEvents = useMemo(() => [...events].sort((a, b) => a.date.getTime() - b.date.getTime()), [events]);
     return (
         <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-8">
@@ -32,8 +32,8 @@ const DashboardView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({
     );
 };
 
-const MembersView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { members } = clubData;
+const MembersView: React.FC = () => {
+    const { members } = useMembers();
     return (
         <div className="bg-white rounded-lg shadow-lg p-6">
             <h2 className="text-2xl font-bold text-slate-800 mb-6">Club Members ({members.length})</h2>
@@ -49,26 +49,26 @@ const MembersView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ c
     );
 };
 
-const CourtBookingView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { courts, bookings, members, currentUser, addBooking, lessonBookings, payForBooking } = clubData;
+const CourtBookingView: React.FC = () => {
+    const { courts, bookings, lessonBookings, addBooking, payForBooking } = useBookings();
+    const { members, currentUser } = useMembers();
     return <CourtBooking courts={courts} bookings={bookings} lessonBookings={lessonBookings} members={members} currentUser={currentUser} onBookCourt={addBooking} onPayForBooking={payForBooking} />;
 };
 
-const CommunityPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { posts, members, currentUser, addPost } = clubData;
+const CommunityPageView: React.FC = () => {
+    const { posts, members, currentUser, addPost } = useClubDataContext();
     return <CommunityView posts={posts} members={members} currentUser={currentUser} onAddPost={addPost} />;
 };
 
-const GroupsPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { 
-        groups, groupMessages, sendGroupMessage, members, currentUser, coaches, 
-        ADMIN_ID, createGroup, updateGroup, deleteGroup, moveMemberToGroup
-    } = clubData;
-    return <GroupsView 
-        groups={groups} 
-        messages={groupMessages} 
-        onSendMessage={sendGroupMessage} 
-        allMembers={members} 
+const GroupsPageView: React.FC = () => {
+    const { groups, groupMessages, sendGroupMessage, coaches, createGroup, updateGroup, deleteGroup, moveMemberToGroup } = useGroups();
+    const { members, currentUser } = useMembers();
+    const { ADMIN_ID } = useClubDataContext();
+    return <GroupsView
+        groups={groups}
+        messages={groupMessages}
+        onSendMessage={sendGroupMessage}
+        allMembers={members}
         currentUser={currentUser}
         coaches={coaches}
         adminId={ADMIN_ID}
@@ -79,30 +79,30 @@ const GroupsPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = (
     />;
 };
 
-const LessonsPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { coaches, lessonBookings, addLessonBooking, currentUser, courts, bookings, members, payForLessonBooking } = clubData;
+const LessonsPageView: React.FC = () => {
+    const { coaches, lessonBookings, addLessonBooking, currentUser, courts, bookings, members, payForLessonBooking } = useClubDataContext();
     return <LessonsView coaches={coaches} lessonBookings={lessonBookings} addLessonBooking={addLessonBooking} currentUser={currentUser} courts={courts} regularBookings={bookings} members={members} onPayForLessonBooking={payForLessonBooking} />;
 };
 
-const LadderPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { ladderPlayers, members, challenges, currentUser, issueChallenge, respondToChallenge, reportMatchResult } = clubData;
+const LadderPageView: React.FC = () => {
+    const { ladderPlayers, members, challenges, currentUser, issueChallenge, respondToChallenge, reportMatchResult } = useClubDataContext();
     return <LadderView ladderPlayers={ladderPlayers} allMembers={members} challenges={challenges} currentUser={currentUser} onIssueChallenge={issueChallenge} onRespondToChallenge={respondToChallenge} onReportResult={reportMatchResult} />;
 };
 
-const FindPartnerPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { partnerRequests, members, currentUser, addPartnerRequest, closePartnerRequest } = clubData;
-    return <FindPartnerView 
-        requests={partnerRequests} 
-        members={members} 
-        currentUser={currentUser} 
-        onAddRequest={addPartnerRequest} 
-        onCloseRequest={closePartnerRequest} 
+const FindPartnerPageView: React.FC = () => {
+    const { partnerRequests, members, currentUser, addPartnerRequest, closePartnerRequest } = useClubDataContext();
+    return <FindPartnerView
+        requests={partnerRequests}
+        members={members}
+        currentUser={currentUser}
+        onAddRequest={addPartnerRequest}
+        onCloseRequest={closePartnerRequest}
     />;
 };
 
-const AnnouncementsPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { announcements, members, addAnnouncement, currentUser, ADMIN_ID } = clubData;
-    return <AnnouncementsView 
+const AnnouncementsPageView: React.FC = () => {
+    const { announcements, members, addAnnouncement, currentUser, ADMIN_ID } = useClubDataContext();
+    return <AnnouncementsView
         announcements={announcements}
         members={members}
         onAddAnnouncement={addAnnouncement}
@@ -115,21 +115,21 @@ const AICoachView: React.FC = () => {
     return <AICoach />;
 };
 
-const SurveysPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    return <SurveysView clubData={clubData} />;
+const SurveysPageView: React.FC = () => {
+    return <SurveysView />;
 };
 
-const MyAccountPageView: React.FC<{ clubData: ReturnType<typeof useClubData>, setCurrentView: (view: View) => void }> = ({ clubData, setCurrentView }) => {
-    return <MyAccountView clubData={clubData} setCurrentView={setCurrentView} />;
+const MyAccountPageView: React.FC<{ setCurrentView: (view: View) => void }> = ({ setCurrentView }) => {
+    return <MyAccountView setCurrentView={setCurrentView} />;
 };
 
-const LearningCenterPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    const { learningArticles } = clubData;
+const LearningCenterPageView: React.FC = () => {
+    const { learningArticles } = useClubDataContext();
     return <LearningCenterView articles={learningArticles} />;
 };
 
-const SettingsPageView: React.FC<{ clubData: ReturnType<typeof useClubData> }> = ({ clubData }) => {
-    return <SettingsView clubData={clubData} />;
+const SettingsPageView: React.FC = () => {
+    return <SettingsView />;
 };
 
 const PrivacyPolicyPageView: React.FC = () => {
@@ -139,43 +139,42 @@ const PrivacyPolicyPageView: React.FC = () => {
 
 const App: React.FC = () => {
     const [currentView, setCurrentView] = useState<View>(View.DASHBOARD);
-    const clubData = useClubData();
-    const { currentUser, notifications, markNotificationsAsRead, ADMIN_ID } = clubData;
+    const { currentUser, notifications, markNotificationsAsRead, ADMIN_ID } = useClubDataContext();
 
     const renderView = () => {
         switch (currentView) {
             case View.DASHBOARD:
-                return <DashboardView clubData={clubData} />;
+                return <DashboardView />;
             case View.MEMBERS:
-                return <MembersView clubData={clubData} />;
+                return <MembersView />;
             case View.BOOKING:
-                return <CourtBookingView clubData={clubData} />;
+                return <CourtBookingView />;
             case View.AI_COACH:
                 return <AICoachView />;
             case View.COMMUNITY:
-                return <CommunityPageView clubData={clubData} />;
+                return <CommunityPageView />;
             case View.SURVEYS:
-                return <SurveysPageView clubData={clubData} />;
+                return <SurveysPageView />;
             case View.LESSONS:
-                return <LessonsPageView clubData={clubData} />;
+                return <LessonsPageView />;
             case View.GROUPS:
-                return <GroupsPageView clubData={clubData} />;
+                return <GroupsPageView />;
             case View.LADDER:
-                return <LadderPageView clubData={clubData} />;
+                return <LadderPageView />;
             case View.FIND_PARTNER:
-                return <FindPartnerPageView clubData={clubData} />;
+                return <FindPartnerPageView />;
             case View.ANNOUNCEMENTS:
-                return <AnnouncementsPageView clubData={clubData} />;
+                return <AnnouncementsPageView />;
             case View.MY_ACCOUNT:
-                return <MyAccountPageView clubData={clubData} setCurrentView={setCurrentView} />;
+                return <MyAccountPageView setCurrentView={setCurrentView} />;
             case View.LEARNING_CENTER:
-                return <LearningCenterPageView clubData={clubData} />;
+                return <LearningCenterPageView />;
             case View.SETTINGS:
-                return <SettingsPageView clubData={clubData} />;
+                return <SettingsPageView />;
             case View.PRIVACY_POLICY:
                 return <PrivacyPolicyPageView />;
             default:
-                return <DashboardView clubData={clubData} />;
+                return <DashboardView />;
         }
     };
     

--- a/components/AdminCreditManagement.tsx
+++ b/components/AdminCreditManagement.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from 'react';
-import { useClubData } from '../hooks/useClubData';
+import { useMembers, useTransactions } from '../hooks/ClubDataContext';
 import { Member, Transaction } from '../types';
 
-interface AdminCreditManagementProps {
-    clubData: ReturnType<typeof useClubData>;
-}
-
-const AdminCreditManagement: React.FC<AdminCreditManagementProps> = ({ clubData }) => {
-    const { members, transactions, awardCredits } = clubData;
+const AdminCreditManagement: React.FC = () => {
+    const { members } = useMembers();
+    const { transactions, awardCredits } = useTransactions();
     const [selectedMemberId, setSelectedMemberId] = useState('');
     const [amount, setAmount] = useState('');
     const [reason, setReason] = useState('');

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Event, Member, AvailabilityStatus } from '../types';
-import { useClubData } from '../hooks/useClubData';
 import MemberAvatar from './MemberAvatar';
 import AvailabilityButtons from './AvailabilityButtons';
 import { ICONS } from '../constants';

--- a/components/NtfIntegration.tsx
+++ b/components/NtfIntegration.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import { useClubData } from '../hooks/useClubData';
+import { useClubDataContext } from '../hooks/ClubDataContext';
 import { Member } from '../types';
 import LoadingSpinner from './LoadingSpinner';
 
-interface NtfIntegrationProps {
-    clubData: ReturnType<typeof useClubData>;
-}
-
-const NtfIntegration: React.FC<NtfIntegrationProps> = ({ clubData }) => {
-    const { ntfSyncStatus, syncWithNtf } = clubData;
+const NtfIntegration: React.FC = () => {
+    const { ntfSyncStatus, syncWithNtf } = useClubDataContext();
     const [isSyncing, setIsSyncing] = React.useState(false);
     const [syncResult, setSyncResult] = React.useState<{ synced: Member[], skipped: Member[] } | null>(null);
 

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import { useClubData } from '../hooks/useClubData';
+import { useClubDataContext } from '../hooks/ClubDataContext';
 import NtfIntegration from './NtfIntegration';
 import AdminCreditManagement from './AdminCreditManagement';
 
-interface SettingsViewProps {
-    clubData: ReturnType<typeof useClubData>;
-}
-
-const SettingsView: React.FC<SettingsViewProps> = ({ clubData }) => {
-    const { currentUser, ADMIN_ID } = clubData;
+const SettingsView: React.FC = () => {
+    const { currentUser, ADMIN_ID } = useClubDataContext();
     
     if (currentUser.id !== ADMIN_ID) {
         return (
@@ -26,8 +22,8 @@ const SettingsView: React.FC<SettingsViewProps> = ({ clubData }) => {
                 <p className="mt-2 text-slate-600">Manage club integrations and other administrative tasks.</p>
             </div>
             
-            <AdminCreditManagement clubData={clubData} />
-            <NtfIntegration clubData={clubData} />
+            <AdminCreditManagement />
+            <NtfIntegration />
         </div>
     );
 };

--- a/components/SurveysView.tsx
+++ b/components/SurveysView.tsx
@@ -1,11 +1,9 @@
 
 import React, { useState, useMemo } from 'react';
 import { Survey, SurveyResponse, Member, SurveyQuestion } from '../types';
-import { useClubData } from '../hooks/useClubData';
+import { useClubDataContext } from '../hooks/ClubDataContext';
 
-interface SurveysViewProps {
-    clubData: ReturnType<typeof useClubData>;
-}
+interface SurveysViewProps {}
 
 const SurveyResults: React.FC<{ survey: Survey, responses: SurveyResponse[] }> = ({ survey, responses }) => {
     const totalResponses = responses.length;
@@ -93,8 +91,8 @@ const SurveyForm: React.FC<{ survey: Survey, onSubmit: (answers: { questionId: s
 };
 
 
-const SurveysView: React.FC<SurveysViewProps> = ({ clubData }) => {
-    const { surveys, surveyResponses, currentUser, submitSurveyResponse } = clubData;
+const SurveysView: React.FC<SurveysViewProps> = () => {
+    const { surveys, surveyResponses, currentUser, submitSurveyResponse } = useClubDataContext();
     const [selectedSurveyId, setSelectedSurveyId] = useState<string | null>(null);
 
     const userResponses = useMemo(() => {

--- a/components/WalletView.tsx
+++ b/components/WalletView.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
-import { useClubData } from '../hooks/useClubData';
+import { useClubDataContext } from '../hooks/ClubDataContext';
 import { View, Transaction } from '../types';
 
 interface MyAccountViewProps {
-    clubData: ReturnType<typeof useClubData>;
     setCurrentView: (view: View) => void;
 }
 
-const MyAccountView: React.FC<MyAccountViewProps> = ({ clubData, setCurrentView }) => {
-    const { currentUser, transactions, toggleNtfConsent, agreeToPolicies, updateMemberDetails, deleteCurrentUser, ADMIN_ID } = clubData;
+const MyAccountView: React.FC<MyAccountViewProps> = ({ setCurrentView }) => {
+    const { currentUser, transactions, toggleNtfConsent, agreeToPolicies, updateMemberDetails, deleteCurrentUser, ADMIN_ID } = useClubDataContext();
 
     const [isEditingName, setIsEditingName] = useState(false);
     const [editedName, setEditedName] = useState(currentUser.name);

--- a/hooks/ClubDataContext.tsx
+++ b/hooks/ClubDataContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext } from 'react';
+import { useClubData } from './useClubData';
+
+const ClubDataContext = createContext<ReturnType<typeof useClubData> | null>(null);
+
+export const ClubDataProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const clubData = useClubData();
+    return <ClubDataContext.Provider value={clubData}>{children}</ClubDataContext.Provider>;
+};
+
+export const useClubDataContext = () => {
+    const ctx = useContext(ClubDataContext);
+    if (!ctx) throw new Error('useClubDataContext must be used within ClubDataProvider');
+    return ctx;
+};
+
+export const useMembers = () => {
+    const { members, currentUser, updateMemberDetails, toggleNtfConsent, agreeToPolicies, deleteCurrentUser } = useClubDataContext();
+    return { members, currentUser, updateMemberDetails, toggleNtfConsent, agreeToPolicies, deleteCurrentUser };
+};
+
+export const useBookings = () => {
+    const { courts, bookings, lessonBookings, addBooking, payForBooking, addLessonBooking, payForLessonBooking } = useClubDataContext();
+    return { courts, bookings, lessonBookings, addBooking, payForBooking, addLessonBooking, payForLessonBooking };
+};
+
+export const useGroups = () => {
+    const { groups, groupMessages, sendGroupMessage, coaches, createGroup, updateGroup, deleteGroup, moveMemberToGroup } = useClubDataContext();
+    return { groups, groupMessages, sendGroupMessage, coaches, createGroup, updateGroup, deleteGroup, moveMemberToGroup };
+};
+
+export const useTransactions = () => {
+    const { transactions, awardCredits } = useClubDataContext();
+    return { transactions, awardCredits };
+};

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { ClubDataProvider } from './hooks/ClubDataContext';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +12,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ClubDataProvider>
+      <App />
+    </ClubDataProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `ClubDataContext` with slice hooks
- wrap the app with `ClubDataProvider`
- update pages and settings/credit components to consume context
- remove leftover `useClubData` imports

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861943c75a88331b5578c51863b2866